### PR TITLE
Require package.json contents.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var semver = require('semver');
 function checkVersions(json, callback) {
   if (!callback) {
     callback = json;
-    json = path.resolve(process.cwd(), 'package.json');
+    json = require(path.resolve(process.cwd(), 'package.json'));
   }
 
   var versions = json.engines;


### PR DESCRIPTION
Without the require, the `json` variable just is the path to `package.json`. I'm pretty sure you meant to actually get the JSON data out of `package.json` instead?

Thanks for the tool—just what I was looking for!
