### PR TITLE
Check would fail if multiple engines were listed in package.json.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function checkEngines(json, callback) {
     range = versions[type];
     cmd = childProcess.spawn(type, ['-v']);
 
-    cmd.stdout.on('data', function(data) {
+    cmd.stdout.on('data', function(type, range, data) {
       var version = data.toString().trim();
 
       if (!semver.satisfies(version, versions[type])) {
@@ -52,7 +52,7 @@ function checkEngines(json, callback) {
       }
 
       done(type, version, range);
-    });
+    }.bind(null, type, range));
   }
 };
 

--- a/spec/check-engines_spec.js
+++ b/spec/check-engines_spec.js
@@ -81,4 +81,32 @@ describe("check-engines", function() {
       });
     });
   });
+
+  describe("two engines in package.json", function() {
+    var spy;
+    var mockNodeChildProcess;
+
+    beforeEach(function() {
+      mockNodeChildProcess = {
+        stdout: new EventEmitter()
+      };
+      childProcess.spawn.withArgs('node', ['-v']).returns(mockNodeChildProcess);
+
+      spy = sinon.spy();
+      checkEngines(require('./package-double.json'), spy);
+      mockChildProcess.stdout.emit('data', '2.11.2\n');
+      mockNodeChildProcess.stdout.emit('data', '4.0.0\n');
+    });
+
+    it("reads package.json from cwd", function() {
+      expect(spy).to.have.been.calledWith(
+        null,
+        {
+        npm: ['2.11.2', '>=2.11.2'],
+        node: ['4.0.0', '>=4.0.0']
+        }
+      );
+    });
+  });
+
 });

--- a/spec/package-double.json
+++ b/spec/package-double.json
@@ -1,0 +1,9 @@
+{
+  "name": "check-engines-test",
+  "version": "1.0.0",
+  "description": "Test package.json for check-engines",
+  "engines": {
+    "npm": ">=2.11.2",
+    "node": ">=4.0.0"
+  }
+}


### PR DESCRIPTION
(version of #2 against most recent version + tests)

The `type` and `range` variables end up only using the last specified `engine`. So, for instance, if `engines` is specified as follows:

```
  "engines": {
    "node": "=0.12.7",
    "npm": "=2.14.5"
  }
```

I get an error message:

```
[Error: [ERROR] npm version (v0.12.7) does not satisfy specified range (=2.14.5)
```

Binding the variables is one way to fix it, if a bit inelegant.
