### PR TITLE
Add error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,12 @@ module.exports = function checkEngines(json, callback) {
   var type;
 
   function done(err, constraints) {
-    info[constraints[0]] = [constraints[1], constraints[2]];
-
     if (err) {
       errors.push(err);
+    }
+
+    if (constraints) {
+      info[constraints[0]] = [constraints[1], constraints[2]];
     }
 
     if (--count) {

--- a/lib/engine-test.js
+++ b/lib/engine-test.js
@@ -45,8 +45,12 @@ EngineTest.prototype.getVersion = function(callback) {
     return;
   }
   var versionExec = childProcess.spawn(this.type, ['-v']);
+  var result = '';
   versionExec.stdout.on('data', function(data) {
-    callback(null, data.toString().trim());
+    result += data.toString();
+  });
+  versionExec.on('close', function() {
+    callback(null, result.trim());
   });
   versionExec.on('error', callback);
 };

--- a/lib/engine-test.js
+++ b/lib/engine-test.js
@@ -12,6 +12,14 @@ EngineTest.prototype.check = function(range, callback) {
 
   this.getVersion(function(err, version) {
     var msg;
+    if (err) {
+      msg = format(
+        'Unable to determine version for (%s). Error was (%s)',
+        type,
+        err.message
+      );
+      return callback(new Error(msg));
+    }
 
     if (!semver.satisfies(version, range)) {
       msg = format(
@@ -36,10 +44,11 @@ EngineTest.prototype.getVersion = function(callback) {
 
     return;
   }
-
-  childProcess.spawn(this.type, ['-v']).stdout.on('data', function(data) {
+  var versionExec = childProcess.spawn(this.type, ['-v']);
+  versionExec.stdout.on('data', function(data) {
     callback(null, data.toString().trim());
   });
+  versionExec.on('error', callback);
 };
 
 module.exports = EngineTest;

--- a/spec/check-engines_spec.js
+++ b/spec/check-engines_spec.js
@@ -48,6 +48,7 @@ describe('check-engines', function() {
         done();
       });
       mockChildProcess.stdout.emit('data', '2.11.2\n');
+      mockChildProcess.emit('close');
     });
 
     afterEach(function() {
@@ -123,6 +124,7 @@ describe('check-engines', function() {
             done();
           });
           mockChildProcess.stdout.emit('data', '1.4.28\n');
+          mockChildProcess.emit('close');
         });
 
         it('calls back with an error', function() {
@@ -141,6 +143,7 @@ describe('check-engines', function() {
             done();
           });
           mockChildProcess.stdout.emit('data', '2.11.2\n');
+          mockChildProcess.emit('close');
         });
 
         it('does not call back with an error', function() {
@@ -168,6 +171,7 @@ describe('check-engines', function() {
         done();
       });
       mockChildProcess.stdout.emit('data', '2.11.2\n');
+      mockChildProcess.emit('close');
     });
 
     afterEach(function() {
@@ -193,6 +197,7 @@ describe('check-engines', function() {
       process.nextTick(function() {
         badCommandMock.emit('error', new Error('unable to execute command'));
         mockChildProcess.stdout.emit('data', '2.11.2\n');
+        mockChildProcess.emit('close');
       });
     });
 

--- a/spec/check-engines_spec.js
+++ b/spec/check-engines_spec.js
@@ -190,16 +190,20 @@ describe('check-engines', function() {
       childProcess.spawn.withArgs(
         'this-is-not-an-executable', ['-v']
       ).returns(badCommandMock);
+      process.nextTick(function() {
+        badCommandMock.emit('error', new Error('unable to execute command'));
+        mockChildProcess.stdout.emit('data', '2.11.2\n');
+      });
     });
 
     it('handles invalid ranges and engines', function(done) {
-      setTimeout(function() {
-        badCommandMock.emit('error', new Error('unable to execute command'));
-      }, 0);
       checkEngines(json, function(error) {
         expect(error).not.to.equal(null);
         expect(error.message).to.contain(
-          'this-is-not-an-executable version (undefined)'
+          'Unable to determine version for (this-is-not-an-executable)'
+        );
+        expect(error.message).to.contain(
+          'does not satisfy specified range (not a valid range)'
         );
         done();
       });

--- a/spec/check-engines_spec.js
+++ b/spec/check-engines_spec.js
@@ -201,12 +201,19 @@ describe('check-engines', function() {
       });
     });
 
-    it('handles invalid ranges and engines', function(done) {
+    it('handles invalid engines', function(done) {
       checkEngines(json, function(error) {
         expect(error).not.to.equal(null);
         expect(error.message).to.contain(
           'Unable to determine version for (this-is-not-an-executable)'
         );
+        done();
+      });
+    });
+
+    it('handles invalid ranges', function(done) {
+      checkEngines(json, function(error) {
+        expect(error).not.to.equal(null);
         expect(error.message).to.contain(
           'does not satisfy specified range (not a valid range)'
         );

--- a/spec/fixtures/invalid-engines.json
+++ b/spec/fixtures/invalid-engines.json
@@ -1,0 +1,8 @@
+{
+  "name": "check-engines-test",
+  "version": "1.0.0",
+  "description": "Test package.json for check-engines",
+  "engines": {
+    "this-is-not-an-executable": ">=4.0.0"
+  }
+}

--- a/spec/fixtures/invalid-engines.json
+++ b/spec/fixtures/invalid-engines.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Test package.json for check-engines",
   "engines": {
+    "npm": "not a valid range",
     "this-is-not-an-executable": ">=4.0.0"
   }
 }


### PR DESCRIPTION
This PR adds handling for:
- Invalid engines (the command does not exist)
- Invalid version returned by `[engine] -v`

Let me know if you want anything changed